### PR TITLE
Adjust clock multiplier for 32MHz quartz

### DIFF
--- a/vga/ctr.v
+++ b/vga/ctr.v
@@ -25,8 +25,8 @@ localparam ADDR_D = 8'h02;
 wire clk;
 
 DCM_SP #(
-	.CLKFX_DIVIDE(2),
-	.CLKFX_MULTIPLY(5)
+	.CLKFX_DIVIDE(7),
+	.CLKFX_MULTIPLY(11)
 ) moj_dcm (
 	.CLKIN(uclk),
 	.CLKFX(clk),


### PR DESCRIPTION
32MHz * 11 / 7 = 50.28MHz
We emit a pixel every second clock, so our effective pixel clock is
50.28MHz / 2 = 25.14 MHz 
which is pretty close to 25.175MHz required for VGA 640x400 mode.